### PR TITLE
Allow mono8 recording and fix bug in local path

### DIFF
--- a/jsk_rosbag_tools/python/jsk_rosbag_tools/bag_to_video.py
+++ b/jsk_rosbag_tools/python/jsk_rosbag_tools/bag_to_video.py
@@ -84,7 +84,9 @@ def bag_to_video(input_bagfile,
     dt = 1.0 / fps
     for image_topic, output_filepath in zip(target_image_topics,
                                             output_filepaths):
-        makedirs(osp.dirname(output_filepath))
+        filepath_dir = osp.dirname(output_filepath)
+        if filepath_dir:
+            makedirs(filepath_dir)
         if audio_exists:
             tmp_videopath = tempfile.NamedTemporaryFile(suffix='.mp4').name
         else:

--- a/jsk_rosbag_tools/python/jsk_rosbag_tools/bag_to_video.py
+++ b/jsk_rosbag_tools/python/jsk_rosbag_tools/bag_to_video.py
@@ -43,7 +43,8 @@ def bag_to_video(input_bagfile,
 
     output_filepaths = []
     target_image_topics = []
-    candidate_topics = get_image_topic_names(input_bagfile, rgb_only=True)
+    candidate_topics = get_image_topic_names(input_bagfile)
+
     if output_filepath is not None:
         if image_topic is None:
             raise ValueError(
@@ -54,7 +55,9 @@ def bag_to_video(input_bagfile,
     else:
         # output_dirpath is specified case.
         if image_topics is None:
-            image_topics = candidate_topics
+            # record all color topics
+            image_topics = get_image_topic_names(input_bagfile,
+                                                 rgb_only=True)
         target_image_topics = image_topics
 
         for image_topic in target_image_topics:

--- a/jsk_rosbag_tools/python/jsk_rosbag_tools/cv.py
+++ b/jsk_rosbag_tools/python/jsk_rosbag_tools/cv.py
@@ -24,6 +24,8 @@ def msg_to_img(msg):
     if msg.encoding in ['bgra8', 'bgr8',
                         'rgba8', 'rgb8']:
         return msg_to_bgr(msg)
+    elif msg.encoding in ['mono8']:
+        return msg_to_mono(msg)
     else:
         return msg_to_np_depth(msg)
 
@@ -87,6 +89,18 @@ def msg_to_bgr(msg, compressed=False):
         else:
             bgr_img = img
     return bgr_img
+
+
+def msg_to_mono(msg, compressed=False):
+    if compressed:
+        np_arr = np.fromstring(msg.data, np.uint8)
+        img = cv2.imdecode(
+            np_arr, cv2.IMREAD_GRAYSCALE)
+    else:
+        img = _bridge.imgmsg_to_cv2(
+            msg,
+            desired_encoding=msg.encoding)
+    return img
 
 
 def msg_to_np_depth(msg, compressed=False, rescale=True):


### PR DESCRIPTION
1. Enable to save grayscale images with `mono8` encoding (useful for mask images)
2. Fix bug when trying to save to local path with `--image-topic`:
```
Traceback (most recent call last):                                         
  File "/home/affonso/jsk_common_ws/src/jsk_common/jsk_rosbag_tools/scripts/bag_to_vid
eo.py", line 57, in <module>                
    main()                                      
  File "/home/affonso/jsk_common_ws/src/jsk_common/jsk_rosbag_tools/scripts/bag_to_vid
eo.py", line 53, in main                         
    audio_topic=args.audio_topic)                                                     
  File "/home/affonso/jsk_common_ws/src/jsk_common/jsk_rosbag_tools/python/jsk_rosbag_
tools/bag_to_video.py", line 88, in bag_to_video
    makedirs(osp.dirname(output_filepath))
  File "/home/affonso/jsk_common_ws/src/jsk_common/jsk_rosbag_tools/python/jsk_rosbag_
tools/makedirs.py", line 30, in makedirs
    raise OSError                                                          
OSError  
(OSError: [Errno 2] No such file or directory: '')  
```